### PR TITLE
Test: dashboard feature unit tests

### DIFF
--- a/app/src/test/java/dev/mperfinan/pokedex/datastore/PreferencesDatastoreManagerTest.kt
+++ b/app/src/test/java/dev/mperfinan/pokedex/datastore/PreferencesDatastoreManagerTest.kt
@@ -11,8 +11,6 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import dev.mperfinan.pokedex.utility.manager.PreferencesDatastoreManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -24,7 +22,6 @@ import java.io.File
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(RobolectricExtension::class)
 class PreferencesDatastoreManagerTest {
-    private val testScope = TestScope(UnconfinedTestDispatcher())
     private val testKey = booleanPreferencesKey("test_key")
 
     private lateinit var context: Context
@@ -47,7 +44,7 @@ class PreferencesDatastoreManagerTest {
 
     @Test
     fun `retrieve should return prefs default value on its initial state`() {
-        testScope.runTest {
+        runTest {
             datastoreManager.retrieve(testKey, true).test {
                 val value = awaitItem()
                 assertThat(value).isTrue()
@@ -58,7 +55,7 @@ class PreferencesDatastoreManagerTest {
 
     @Test
     fun `retrieve should return newly assigned prefs value`() {
-        testScope.runTest {
+        runTest {
             datastoreManager.store(testKey, false)
 
             datastoreManager.retrieve(testKey, true).test {
@@ -71,7 +68,7 @@ class PreferencesDatastoreManagerTest {
 
     @Test
     fun `retrieve should return default value once assigned prefs value is cleared`() {
-        testScope.runTest {
+        runTest {
             datastoreManager.store(testKey, false)
 
             datastoreManager.clear(testKey)

--- a/app/src/test/java/dev/mperfinan/pokedex/datastore/UserPreferencesDatastoreTest.kt
+++ b/app/src/test/java/dev/mperfinan/pokedex/datastore/UserPreferencesDatastoreTest.kt
@@ -12,8 +12,6 @@ import dev.mperfinan.pokedex.data.source.datastore.IUserPreferencesDatastore
 import dev.mperfinan.pokedex.data.source.datastore.UserPreferencesDatastore
 import dev.mperfinan.pokedex.utility.manager.PreferencesDatastoreManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -25,7 +23,6 @@ import java.io.File
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(RobolectricExtension::class)
 class UserPreferencesDatastoreTest {
-    private val testScope = TestScope(UnconfinedTestDispatcher())
     private lateinit var context: Context
     private lateinit var testFile: File
     private lateinit var dataStore: DataStore<Preferences>
@@ -48,7 +45,7 @@ class UserPreferencesDatastoreTest {
 
     @Test
     fun `getIsAppFirstLaunch should retrieve (true) as IS_APP_FIRST_LAUNCH's initial value when performed`() {
-        testScope.runTest {
+        runTest {
             userPreferencesDatastore.getIsAppFirstLaunch().test {
                 val isAppFirstLaunch = awaitItem()
                 assertThat(isAppFirstLaunch).isTrue()
@@ -59,7 +56,7 @@ class UserPreferencesDatastoreTest {
 
     @Test
     fun `getIsAppFirstLaunch should retrieve IS_APP_FIRST_LAUNCH's new value when setIsAppFirstLaunch is performed`() {
-        testScope.runTest {
+        runTest {
             userPreferencesDatastore.setIsAppFirstLaunch(false)
             userPreferencesDatastore.getIsAppFirstLaunch().test {
                 val isAppFirstLaunch = awaitItem()

--- a/app/src/test/java/dev/mperfinan/pokedex/fake/network/FakeNewsService.kt
+++ b/app/src/test/java/dev/mperfinan/pokedex/fake/network/FakeNewsService.kt
@@ -1,0 +1,24 @@
+package dev.mperfinan.pokedex.fake.network
+
+import com.google.gson.Gson
+import dev.mperfinan.pokedex.data.network.ApiResult
+import dev.mperfinan.pokedex.data.network.model.news.NewsArticleDto
+import dev.mperfinan.pokedex.data.network.service.NewsApiService
+
+class FakeNewsService : NewsApiService {
+    private val newsData = loadNewsJson()
+
+    override suspend fun getPokemonNews(
+        index: Int,
+        count: Int,
+    ): ApiResult<List<NewsArticleDto>> {
+        return ApiResult.Success(newsData)
+    }
+
+    private fun loadNewsJson(): List<NewsArticleDto> {
+        val inputStream = javaClass.classLoader!!.getResourceAsStream("mock-response/pokemon_news.json")
+
+        val json = inputStream.bufferedReader().use { it.readText() }
+        return Gson().fromJson(json, Array<NewsArticleDto>::class.java).toList()
+    }
+}

--- a/app/src/test/java/dev/mperfinan/pokedex/network/NewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/dev/mperfinan/pokedex/network/NewsNetworkDataSourceTest.kt
@@ -1,0 +1,39 @@
+package dev.mperfinan.pokedex.network
+
+import com.google.common.truth.Truth.assertThat
+import dev.mperfinan.pokedex.data.network.ApiResult
+import dev.mperfinan.pokedex.data.network.onSuccess
+import dev.mperfinan.pokedex.data.source.remote.INewsNetworkDataSource
+import dev.mperfinan.pokedex.data.source.remote.NewsNetworkDataSource
+import dev.mperfinan.pokedex.fake.network.FakeNewsService
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@ExperimentalCoroutinesApi
+class NewsNetworkDataSourceTest {
+    private lateinit var newsNetworkDataSource: INewsNetworkDataSource
+
+    @BeforeEach
+    fun setup() {
+        newsNetworkDataSource = NewsNetworkDataSource(FakeNewsService())
+    }
+
+    @Test
+    fun `getPokemonNews should return success with pokemon news data`() {
+        runTest {
+            val result = newsNetworkDataSource.getPokemonNews(0, 10)
+
+            assertThat(result).isInstanceOf(ApiResult.Success::class.java)
+
+            result.onSuccess { news ->
+                assertThat(news).isNotEmpty()
+                assertThat(news).hasSize(10)
+                assertThat(news.first().title).isEqualTo(
+                    "Dynamax Eevee Debuts in Pokémon&nbsp;GO’s Dynamax Eevee Max Battle Weekend",
+                )
+            }
+        }
+    }
+}

--- a/app/src/test/java/dev/mperfinan/pokedex/network/NewsServiceTest.kt
+++ b/app/src/test/java/dev/mperfinan/pokedex/network/NewsServiceTest.kt
@@ -1,0 +1,44 @@
+package dev.mperfinan.pokedex.network
+
+import com.google.common.truth.Truth.assertThat
+import dev.mperfinan.pokedex.data.network.ApiResult
+import dev.mperfinan.pokedex.data.network.onSuccess
+import dev.mperfinan.pokedex.data.network.service.NewsApiService
+import dev.mperfinan.pokedex.utility.PredefinedMockWebServer
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
+import java.net.HttpURLConnection
+
+@ExperimentalCoroutinesApi
+@ExtendWith(RobolectricExtension::class)
+class NewsServiceTest : PredefinedMockWebServer<NewsApiService>() {
+    private lateinit var newsApiService: NewsApiService
+
+    @BeforeEach
+    fun setup() {
+        newsApiService = createService(NewsApiService::class.java)
+    }
+
+    @Test
+    fun `getPokemonNews should retrieve 200 response when request is valid`() {
+        runTest {
+            enqueueResponse("pokemon_news.json", HttpURLConnection.HTTP_OK)
+
+            val result = newsApiService.getPokemonNews(0, 10)
+
+            assertThat(result).isInstanceOf(ApiResult.Success::class.java)
+
+            result.onSuccess { news ->
+                assertThat(news).isNotEmpty()
+                assertThat(news).hasSize(10)
+                assertThat(news.first().title).isEqualTo(
+                    "Dynamax Eevee Debuts in Pokémon&nbsp;GO’s Dynamax Eevee Max Battle Weekend",
+                )
+            }
+        }
+    }
+}

--- a/app/src/test/java/dev/mperfinan/pokedex/repository/NewsRepositoryTest.kt
+++ b/app/src/test/java/dev/mperfinan/pokedex/repository/NewsRepositoryTest.kt
@@ -1,0 +1,52 @@
+package dev.mperfinan.pokedex.repository
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import dev.mperfinan.pokedex.data.repository.INewsRepository
+import dev.mperfinan.pokedex.data.repository.NewsRepository
+import dev.mperfinan.pokedex.data.source.remote.INewsNetworkDataSource
+import dev.mperfinan.pokedex.data.source.remote.NewsNetworkDataSource
+import dev.mperfinan.pokedex.fake.network.FakeNewsService
+import dev.mperfinan.pokedex.utility.Result
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@ExperimentalCoroutinesApi
+class NewsRepositoryTest {
+    private val testScheduler = TestCoroutineScheduler()
+    private val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+    private lateinit var newsNetworkDataSource: INewsNetworkDataSource
+    private lateinit var newsRepository: INewsRepository
+
+    @BeforeEach
+    fun setup() {
+        newsNetworkDataSource = NewsNetworkDataSource(FakeNewsService())
+        newsRepository = NewsRepository(newsNetworkDataSource, testDispatcher)
+    }
+
+    @Test
+    fun `getPokemonNews should retrieve pokemon news from a successful assumed remote api request`() {
+        runTest(testScheduler) {
+            newsRepository.getPokemonNews(null, null).test {
+                awaitItem()
+                val result = awaitItem() as Result.Success
+
+                assertThat(result).isInstanceOf(Result.Success::class.java)
+
+                val pokemonNews = result.data
+
+                assertThat(pokemonNews).isNotEmpty()
+                assertThat(pokemonNews).hasSize(10)
+                assertThat(pokemonNews.first().title).isEqualTo(
+                    "Dynamax Eevee Debuts in Pokémon GO’s Dynamax Eevee Max Battle Weekend",
+                )
+
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+    }
+}

--- a/app/src/test/java/dev/mperfinan/pokedex/repository/UserPreferencesRepositoryTest.kt
+++ b/app/src/test/java/dev/mperfinan/pokedex/repository/UserPreferencesRepositoryTest.kt
@@ -7,18 +7,13 @@ import dev.mperfinan.pokedex.data.repository.UserPreferencesRepository
 import dev.mperfinan.pokedex.data.source.datastore.IUserPreferencesDatastore
 import dev.mperfinan.pokedex.fake.datastore.FakeUserPreferencesDatastore
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class UserPreferencesRepositoryTest {
-    private val testScope = TestScope(UnconfinedTestDispatcher())
-
     private lateinit var userPreferencesDatastore: IUserPreferencesDatastore
-
     private lateinit var userPreferencesRepository: IUserPreferencesRepository
 
     @BeforeEach
@@ -30,7 +25,7 @@ class UserPreferencesRepositoryTest {
 
     @Test
     fun `getIsAppFirstLaunch should retrieve prefs default value as IS_APP_FIRST_LAUNCH is first initialized`() {
-        testScope.runTest {
+        runTest {
             userPreferencesRepository.getIsAppFirstLaunch().test {
                 val isAppFirstLaunch = awaitItem()
                 assertThat(isAppFirstLaunch).isTrue()
@@ -41,7 +36,7 @@ class UserPreferencesRepositoryTest {
 
     @Test
     fun `getIsAppFirstLaunch should retrieve prefs new value when IS_APP_FIRST_LAUNCH assigns new one`() {
-        testScope.runTest {
+        runTest {
             userPreferencesRepository.setIsAppFirstLaunch(false)
             userPreferencesRepository.getIsAppFirstLaunch().test {
                 val isAppFirstLaunch = awaitItem()

--- a/app/src/test/java/dev/mperfinan/pokedex/utility/PredefinedMockWebServer.kt
+++ b/app/src/test/java/dev/mperfinan/pokedex/utility/PredefinedMockWebServer.kt
@@ -1,0 +1,65 @@
+package dev.mperfinan.pokedex.utility
+
+import dev.mperfinan.pokedex.data.network.adapter.NetworkResultCallAdapterFactory
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okio.buffer
+import okio.source
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import java.nio.charset.StandardCharsets
+
+open class PredefinedMockWebServer<T> {
+    private lateinit var mockWebServer: MockWebServer
+
+    @BeforeEach
+    fun startMockServer() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+    }
+
+    @AfterEach
+    fun shutdownServer() {
+        mockWebServer.shutdown()
+    }
+
+    fun createService(serviceClass: Class<T>): T {
+        val okHttpClient = OkHttpClient.Builder().build()
+
+        return Retrofit.Builder()
+            .client(okHttpClient)
+            .baseUrl(mockWebServer.url("/"))
+            .addConverterFactory(GsonConverterFactory.create())
+            .addCallAdapterFactory(NetworkResultCallAdapterFactory.Companion.create())
+            .build()
+            .create(serviceClass)
+    }
+
+    fun enqueueResponse(
+        fileName: String,
+        responseCode: Int,
+    ) {
+        enqueueResponse(fileName, emptyMap(), responseCode)
+    }
+
+    private fun enqueueResponse(
+        fileName: String,
+        headers: Map<String, String>,
+        statusCode: Int,
+    ) {
+        val inputStream = javaClass.classLoader!!.getResourceAsStream("mock-response/$fileName")
+        val source = inputStream.source().buffer()
+        val mockResponse =
+            MockResponse().apply {
+                setBody(source.readString(StandardCharsets.UTF_8))
+                setResponseCode(statusCode)
+            }
+        for ((key, value) in headers) {
+            mockResponse.addHeader(key, value)
+        }
+        mockWebServer.enqueue(mockResponse)
+    }
+}

--- a/app/src/test/java/dev/mperfinan/pokedex/viewmodel/DashboardVMTest.kt
+++ b/app/src/test/java/dev/mperfinan/pokedex/viewmodel/DashboardVMTest.kt
@@ -1,0 +1,57 @@
+package dev.mperfinan.pokedex.viewmodel
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import dev.mperfinan.pokedex.data.repository.INewsRepository
+import dev.mperfinan.pokedex.data.repository.NewsRepository
+import dev.mperfinan.pokedex.data.source.remote.INewsNetworkDataSource
+import dev.mperfinan.pokedex.data.source.remote.NewsNetworkDataSource
+import dev.mperfinan.pokedex.fake.network.FakeNewsService
+import dev.mperfinan.pokedex.feature.dashboard.DashboardUiState
+import dev.mperfinan.pokedex.feature.dashboard.DashboardVM
+import dev.mperfinan.pokedex.utility.MainDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExperimentalCoroutinesApi
+@ExtendWith(MainDispatcherRule::class)
+class DashboardVMTest {
+    private val testScheduler = TestCoroutineScheduler()
+    private val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+    private lateinit var newsNetworkDataSource: INewsNetworkDataSource
+    private lateinit var newsRepository: INewsRepository
+    private lateinit var dashboardVM: DashboardVM
+
+    @BeforeEach
+    fun setup() {
+        newsNetworkDataSource = NewsNetworkDataSource(FakeNewsService())
+        newsRepository = NewsRepository(newsNetworkDataSource, testDispatcher)
+
+        dashboardVM = DashboardVM(newsRepository)
+    }
+
+    @Test
+    fun `uiState should emit DashboardUiState Success state when repository successfully supply pokemon news data`() {
+        runTest(testScheduler) {
+            dashboardVM.uiState.test {
+                assertThat(awaitItem()).isEqualTo(DashboardUiState.Loading)
+
+                val uiState = awaitItem() as DashboardUiState.Success
+                val newsArticles = uiState.newsArticles
+
+                assertThat(newsArticles).isNotEmpty()
+                assertThat(newsArticles).hasSize(10)
+                assertThat(newsArticles.first().title).isEqualTo(
+                    "Dynamax Eevee Debuts in Pokémon GO’s Dynamax Eevee Max Battle Weekend",
+                )
+
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+    }
+}

--- a/app/src/test/java/dev/mperfinan/pokedex/viewmodel/MainVMTest.kt
+++ b/app/src/test/java/dev/mperfinan/pokedex/viewmodel/MainVMTest.kt
@@ -1,19 +1,15 @@
 package dev.mperfinan.pokedex.viewmodel
 
+import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import dev.mperfinan.pokedex.MainUiState
 import dev.mperfinan.pokedex.MainVM
-import dev.mperfinan.pokedex.data.model.UserPreferencesData
 import dev.mperfinan.pokedex.data.repository.IUserPreferencesRepository
 import dev.mperfinan.pokedex.data.repository.UserPreferencesRepository
 import dev.mperfinan.pokedex.data.source.datastore.IUserPreferencesDatastore
 import dev.mperfinan.pokedex.fake.datastore.FakeUserPreferencesDatastore
 import dev.mperfinan.pokedex.utility.MainDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -24,7 +20,6 @@ import org.junit.jupiter.api.extension.ExtendWith
 class MainVMTest {
     private lateinit var userPreferencesDatastore: IUserPreferencesDatastore
     private lateinit var userPreferencesRepository: IUserPreferencesRepository
-
     private lateinit var viewModel: MainVM
 
     @BeforeEach
@@ -36,41 +31,32 @@ class MainVMTest {
     }
 
     @Test
-    fun `mainUiState should retrieve (MainUiState_Loading) state value when first initialized`() {
-        runTest {
-            assertThat(viewModel.mainUiState.value).isEqualTo(MainUiState.Loading)
-        }
-    }
-
-    @Test
     fun `mainUiState should retrieve (MainUiState_Success) state and collect (isAppFirstLaunch) default start value`() {
         runTest {
-            val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.mainUiState.collect() }
+            viewModel.mainUiState.test {
+                val mainUiState = awaitItem() as MainUiState.Success
+                val isAppFirstLaunch = mainUiState.userPreferencesData.isAppFirstLaunch
 
-            val isAppFirstLaunch = userPreferencesRepository.getIsAppFirstLaunch().first()
-            val userPreferencesData = UserPreferencesData(isAppFirstLaunch = isAppFirstLaunch)
+                assertThat(isAppFirstLaunch).isTrue()
 
-            assertThat(userPreferencesData.isAppFirstLaunch).isTrue()
-            assertThat(viewModel.mainUiState.value).isEqualTo(MainUiState.Success(userPreferencesData))
-
-            collectJob.cancel()
+                cancelAndConsumeRemainingEvents()
+            }
         }
     }
 
     @Test
     fun `mainUiState should retrieve (MainUiState_Success) state and collect (isAppFirstLaunch) new value`() {
         runTest {
-            val collectJob = launch(UnconfinedTestDispatcher()) { viewModel.mainUiState.collect() }
-
             userPreferencesRepository.setIsAppFirstLaunch(false)
 
-            val isAppFirstLaunch = userPreferencesRepository.getIsAppFirstLaunch().first()
-            val userPreferencesData = UserPreferencesData(isAppFirstLaunch = isAppFirstLaunch)
+            viewModel.mainUiState.test {
+                val mainUiState = awaitItem() as MainUiState.Success
+                val isAppFirstLaunch = mainUiState.userPreferencesData.isAppFirstLaunch
 
-            assertThat(userPreferencesData.isAppFirstLaunch).isFalse()
-            assertThat(viewModel.mainUiState.value).isEqualTo(MainUiState.Success(userPreferencesData))
+                assertThat(isAppFirstLaunch).isFalse()
 
-            collectJob.cancel()
+                cancelAndConsumeRemainingEvents()
+            }
         }
     }
 }

--- a/app/src/test/resources/mock-response/pokemon_news.json
+++ b/app/src/test/resources/mock-response/pokemon_news.json
@@ -1,0 +1,218 @@
+[
+  {
+    "id": 0,
+    "type": "news",
+    "title": "Dynamax Eevee Debuts in Pokémon&nbsp;GO’s Dynamax Eevee Max Battle Weekend",
+    "shortDescription": "1 Dynamax Eevee + 8 possible Evolutions = one busy weekend",
+    "url": "/us/pokemon-news/dynamax-eevee-debuts-in-pokemon-gos-dynamax-eevee-max-battle-weekend",
+    "image": "/static-assets/content-assets/cms2/img/video-games/_tiles/pokemon-go/2025/11/21/pokemon-go-169.png",
+    "mobileImage": "",
+    "alt": "Dynamax Eevee Debuts in Pokémon GO’s Dynamax Eevee Max Battle Weekend",
+    "date": "November 21, 2025",
+    "tags": [
+      {
+        "id": "video-games-apps",
+        "label": "Video Games & Apps"
+      },
+      {
+        "id": "pokemon-go",
+        "label": "Pokémon GO"
+      }
+    ],
+    "external": false,
+    "externalTitle": "",
+    "externalClass": ""
+  },
+  {
+    "id": 1,
+    "type": "news",
+    "title": "Get the New Pokémon TCG Expansion, <em>Mega Evolution—Ascended Heroes</em>, on January 30, 2026",
+    "shortDescription": "The upcoming expansion features new Mega Evolution Pokémon&nbsp;ex along with Trainer’s Pokémon and Stellar Tera Pokémon&nbsp;ex.",
+    "url": "/us/pokemon-news/get-the-new-pokemon-tcg-expansion-mega-evolution-ascended-heroes-on-january-30-2026",
+    "image": "/static-assets/content-assets/cms2/img/trading-card-game/_tiles/me/me2pt5/announce/me2pt5-announce-169-en.png",
+    "mobileImage": "",
+    "alt": "Get the New Pokémon TCG Expansion, Mega Evolution—Ascended Heroes, on January 30, 2026",
+    "date": "November 20, 2025",
+    "tags": [
+      {
+        "id": "trading-card-game",
+        "label": "Trading Card Game"
+      }
+    ],
+    "external": false,
+    "externalTitle": "",
+    "externalClass": ""
+  },
+  {
+    "id": 2,
+    "type": "news",
+    "title": "Earn Chesnaughtite in <em>Pokémon Legends: Z&#8209;A</em> Ranked Battles Season 3",
+    "shortDescription": "Take on players from around the world to climb the ranks and earn useful in-game rewards.",
+    "url": "/us/pokemon-news/earn-chesnaughtite-in-pokemon-legends-z-a-ranked-battles-season-3",
+    "image": "/static-assets/content-assets/cms2/img/video-games/_tiles/pokemon-legends-z-a/events/2025/11/20/pokemon-legends-z-a-169-en.png",
+    "mobileImage": "",
+    "alt": "Earn Chesnaughtite in Pokémon Legends: Z-A Ranked Battles Season 3",
+    "date": "November 20, 2025",
+    "tags": [
+      {
+        "id": "video-games-apps",
+        "label": "Video Games & Apps"
+      }
+    ],
+    "external": false,
+    "externalTitle": "",
+    "externalClass": ""
+  },
+  {
+    "id": 3,
+    "type": "news",
+    "title": "Vaporeon Is Now Available in Pokémon&nbsp;UNITE",
+    "shortDescription": "Make a splash with the Water-type Eevee Evolution.",
+    "url": "/us/pokemon-news/vaporeon-is-now-available-in-pokemon-unite",
+    "image": "/static-assets/content-assets/cms2/img/video-games/_tiles/pokemon-unite/2025/11/20/pokemon-unite-169.png",
+    "mobileImage": "",
+    "alt": "Vaporeon Is Now Available in Pokémon UNITE",
+    "date": "November 20, 2025",
+    "tags": [
+      {
+        "id": "video-games-apps",
+        "label": "Video Games & Apps"
+      }
+    ],
+    "external": false,
+    "externalTitle": "",
+    "externalClass": ""
+  },
+  {
+    "id": 4,
+    "type": "news",
+    "title": "Mega Zeraora Makes Its Debut in <em>Pokémon Legends: Z&#8209;A – Mega Dimension</em>",
+    "shortDescription": "See the new trailer for this Mega-Evolved Mythical Pokémon that you can meet in the upcoming DLC adventure.",
+    "url": "/us/pokemon-news/mega-zeraora-makes-its-debut-in-pokemon-legends-z-a-mega-dimension",
+    "image": "/static-assets/content-assets/cms2/img/video-games/_tiles/pokemon-legends-z-a/dlc/2025/11/19/pokemon-legends-z-a-169-en.png",
+    "mobileImage": "",
+    "alt": "Mega Zeraora Makes Its Debut in Pokémon Legends: Z-A – Mega Dimension",
+    "date": "November 19, 2025",
+    "tags": [
+      {
+        "id": "video-games-apps",
+        "label": "Video Games & Apps"
+      }
+    ],
+    "external": false,
+    "externalTitle": "",
+    "externalClass": ""
+  },
+  {
+    "id": 5,
+    "type": "news",
+    "title": "Learn How to Climb the Ranks in the Z-A Battle Club",
+    "shortDescription": "Dive into this fun, free-for-all game mode with plenty of strategy.",
+    "url": "/us/strategy/learn-how-to-climb-the-ranks-in-the-z-a-battle-club",
+    "image": "/static-assets/content-assets/cms2/img/video-games/_tiles/pokemon-legends-z-a/strategy/battle-club/pokemon-legends-z-a-169-en.png",
+    "mobileImage": "",
+    "alt": "Learn How to Climb the Ranks in the Z-A Battle Club",
+    "date": "November 19, 2025",
+    "tags": [
+      {
+        "id": "video-games-apps",
+        "label": "Video Games & Apps"
+      }
+    ],
+    "external": false,
+    "externalTitle": "",
+    "externalClass": ""
+  },
+  {
+    "id": 6,
+    "type": "news",
+    "title": "Get Amped for Shiny Morpeko in Pokémon&nbsp;GO’s High Voltage Event",
+    "shortDescription": "Electric-type Pokémon shine brightly in an event that celebrates their power.",
+    "url": "/us/pokemon-news/get-amped-for-shiny-morpeko-in-pokemon-gos-high-voltage-event",
+    "image": "/static-assets/content-assets/cms2/img/video-games/_tiles/pokemon-go/2025/11/18/pokemon-go-169.png",
+    "mobileImage": "",
+    "alt": "Get Amped for Shiny Morpeko in Pokémon GO’s High Voltage Event",
+    "date": "November 18, 2025",
+    "tags": [
+      {
+        "id": "video-games-apps",
+        "label": "Video Games & Apps"
+      },
+      {
+        "id": "pokemon-go",
+        "label": "Pokémon GO"
+      }
+    ],
+    "external": false,
+    "externalTitle": "",
+    "externalClass": ""
+  },
+  {
+    "id": 7,
+    "type": "news",
+    "title": "Pokémon Trading Card Game Pocket Mega Pidgeot&nbsp;ex Drop Event",
+    "shortDescription": "Win solo battles to earn special promo cards with new artwork, including a Mega Pidgeot&nbsp;ex promo card.",
+    "url": "/us/pokemon-news/pokemon-trading-card-game-pocket-mega-pidgeot-ex-drop-event",
+    "image": "/static-assets/content-assets/cms2/img/video-games/_tiles/tcg-pocket/2025/11/18/pokemon-tcg-pocket-169-en.png",
+    "mobileImage": "",
+    "alt": "Pokémon Trading Card Game Pocket Mega Pidgeot ex Drop Event",
+    "date": "November 18, 2025",
+    "tags": [
+      {
+        "id": "video-games-apps",
+        "label": "Video Games & Apps"
+      }
+    ],
+    "external": false,
+    "externalTitle": "",
+    "externalClass": ""
+  },
+  {
+    "id": 8,
+    "type": "news",
+    "title": "Get Rewards During the 2026 Latin America International Championships Livestream",
+    "shortDescription": "Watch the livestream to claim a Champion’s Pokémon, Pokémon&nbsp;TCG Live rewards, and more.",
+    "url": "/us/pokemon-news/get-rewards-during-the-2026-latin-america-international-championships-livestream",
+    "image": "/static-assets/content-assets/cms2/img/attend-events/championship/2026-laic/rewards/2026-laic-169.png",
+    "mobileImage": "",
+    "alt": "Get Rewards During the 2026 Latin America International Championships Livestream",
+    "date": "November 18, 2025",
+    "tags": [
+      {
+        "id": "video-games-apps",
+        "label": "Video Games & Apps"
+      },
+      {
+        "id": "trading-card-game",
+        "label": "Trading Card Game"
+      },
+      {
+        "id": "play-pokemon-events",
+        "label": "Play! Pokémon Events"
+      }
+    ],
+    "external": false,
+    "externalTitle": "",
+    "externalClass": ""
+  },
+  {
+    "id": 9,
+    "type": "strategy",
+    "title": "Top Competitive Cards from <em>Mega Evolution—Phantasmal Flames</em>",
+    "shortDescription": "Xander Pero spotlights the hottest cards.",
+    "url": "/us/strategy/top-competitive-cards-from-mega-evolution-phantasmal-flames",
+    "image": "/static-assets/content-assets/cms2/img/trading-card-game/_tiles/me/me02/top-cards/me02-top-cards-169-en.png",
+    "mobileImage": "",
+    "alt": "Top Competitive Cards from Mega Evolution—Phantasmal Flames",
+    "date": "November 17, 2025",
+    "tags": [
+      {
+        "id": "trading-card-game",
+        "label": "Trading Card Game"
+      }
+    ],
+    "external": false,
+    "externalTitle": "",
+    "externalClass": ""
+  }
+]


### PR DESCRIPTION
- setup reusable PredefinedMockWebServer.kt for running MockWebServer
- setup necessary fakes as test-doubles of units under test
- write tests for DashboardVM
- write tests for NewsRepository
- write tests for NewsDataSource
- write tests for NewsService
- adjust existing test files to use default testScope instead of custom ones